### PR TITLE
Fix install requirement specs in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ setup(
         'Framework :: Django',
         'Intended Audience :: Developers',
     ],
-    requires=[
-        'Django (>=1.6)',
-        'six (>=1.7.3)',
+    install_requires=[
+        'Django>=1.6',
+        'six>=1.7.3',
     ],
 )


### PR DESCRIPTION
Requirements for django-classy-settings 1.0.1 were not specified in the correct manner.