### PR TITLE
Allow `python setup.py test`, rewrite tox config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
 
 # Installer logs
 pip-log.txt

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,5 @@ setup(
     install_requires=[
         'Django>=1.6',
     ],
+    test_suite='tests',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,74 +1,45 @@
 [tox]
+# generative list of environments (matrix) to run by default
 envlist =
-    clean,
-    py27-d1.7, py26-d1.8,
-    py33-d1.7, py33-d1.8,
-    py34-d1.7, py34-d1.8,
-    pypy-d1.7, pypy-d1.8,
-    pypy3-d1.7, pypy3-d1.8,
-    report
-[testenv]
-commands= coverage run -m unittest discover
+  clean,
+  {py27,py33,py34,py35,pypy,pypy3}-django{1.6,1.7,1.8,1.9},
+  report
 
-[testenv:clean]
+# don't require *all* specified python versions (2.7, 3.3, 3.4, 3.5, ...)
+skip_missing_interpreters=True
+
+
+[testenv]
+# force clean environment each time
+recreate=True
+
+# use setup.py to build sdist, then install from that (validate setup.py)
+usedevelop=False
+
+# all roads lead to `python setup.py test`
+commands=
+  coverage run --append --source=cbs setup.py test
+
+# coverage + django factor based (conditional) dependencies
 deps=
   coverage
+  django1.6: django>=1.6,<1.7
+  django1.7: django>=1.7,<1.8
+  django1.8: django>=1.8,<1.9
+  django1.9: django==1.9rc2
+
+
+[testenv:clean,report]
+# the `clean` and `report` environments only need coverage installed
+skip_install=True
+deps=
+  coverage
+
+[testenv:clean]
 commands=
   coverage erase
 
 [testenv:report]
-deps=
-  coverage
 commands=
-  coverage report --include "cbs/*"
-  coverage html --include "cbs/*"
-
-# Python 2.7
-
-[testenv:py27-d1.7]
-deps = django>=1.7,<1.8
-  coverage
-
-[testenv:py27-d1.8]
-deps = django>=1.8,<1.9
-  coverage
-
-# Python 3.3
-
-[testenv:py33-d1.7]
-deps = django>=1.7,<1.8
-  coverage
-
-[testenv:py33-d1.8]
-deps = django>=1.8,<1.9
-  coverage
-
-# Python 3.4
-
-[testenv:py34-d1.7]
-deps = django>=1.7,<1.8
-  coverage
-
-[testenv:py34-d1.8]
-deps = django>=1.8,<1.9
-  coverage
-
-# Pypy
-
-[testenv:pypy-d1.7]
-deps = django>=1.7,<1.8
-  coverage
-
-[testenv:pypy-d1.8]
-deps = django>=1.8,<1.9
-  coverage
-
-# Pypy3
-
-[testenv:pypy3-d1.7]
-deps = django>=1.7,<1.8
-  coverage
-
-[testenv:pypy3-d1.8]
-deps = django>=1.8,<1.9
-  coverage
+  coverage report
+  coverage html


### PR DESCRIPTION
Fixes the following:
* Can now run `python setup.py test`.
* Tox uses `setup.py test` ("There should be one-- and preferably only one --obvious way to do it.")
* Tests run against Django 1.9 RC2.
* DRY Tox config - use [generative environment lists](https://testrun.org/tox/latest/config.html#generative-envlist).
* Report aggregate coverage for all Tox environments run, not just the last (`coverage run --append`).
* Report missed coverage for all files in cbs (`coverage run --source=cbs`).
* Recreate Tox environments every time, ensuring test validity (`recreate=True`).