### PR TITLE
Using `@cbs.envbool(key='FOO')` returns value from `os.environ['FOO']` instead of parsing it.

### DIFF
--- a/cbs/__init__.py
+++ b/cbs/__init__.py
@@ -42,7 +42,7 @@ class env(object):
     '''
     def __new__(cls, *args, **kwargs):
         if not args:
-            return partial(env, **kwargs)
+            return partial(cls, **kwargs)
         return object.__new__(cls)
 
     def __init__(self, getter, key=None, type=None, prefix=None):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -105,3 +105,14 @@ class TestEnv(unittest.TestCase):
         del s.SETTING
         with self.assertRaises(ValueError):
             s.SETTING
+
+    def test_envbool_with_specified_key_set_true(self):
+
+        class Settings:
+
+            @cbs.envbool(key='MY_SETTING')
+            def SETTING(self):
+                return False
+
+        os.environ['MY_SETTING'] = 'true'
+        self.assertEqual(Settings().SETTING, True)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -106,6 +106,64 @@ class TestEnv(unittest.TestCase):
         with self.assertRaises(ValueError):
             s.SETTING
 
+    def test_envbool_default(self):
+
+        class Settings:
+
+            @cbs.envbool
+            def SETTING(self):
+                return True
+
+        self.assertEqual(Settings().SETTING, True)
+
+    def test_envbool_set_true(self):
+
+        class Settings:
+
+            @cbs.envbool
+            def SETTING(self):
+                return False
+
+        for value in [
+            'y', 'yes', 'on', 't', 'true', '1',
+            'Y', 'YES', 'ON', 'T', 'TRUE',
+            'Y ', ' YES', '  ON', '\tT', '\nTRUE',
+            'yEs', 'On', 'True',
+        ]:
+            os.environ['SETTING'] = value
+            self.assertEqual(Settings().SETTING, True)
+
+    def test_envbool_set_false(self):
+
+        class Settings:
+
+            @cbs.envbool
+            def SETTING(self):
+                return True
+
+        for value in [
+            'n', 'no', 'off', 'f', 'false', '0',
+            'N', 'NO', 'OFF', 'F', 'FALSE',
+            ' N ', 'NO ', ' OFF', 'F\t', 'FALSE\n',
+            'No', 'Off', 'fALSE',
+        ]:
+            os.environ['SETTING'] = value
+            self.assertEqual(Settings().SETTING, False)
+
+    def test_envbool_set_invalid(self):
+
+        class Settings:
+
+            @cbs.envbool
+            def SETTING(self):
+                return True
+
+        for value in [
+            'yep', 'nah', '-1', '10', '00', '', 'Y Y',
+        ]:
+            os.environ['SETTING'] = value
+            self.assertRaises(ValueError, lambda: Settings().SETTING)
+
     def test_envbool_with_specified_key_set_true(self):
 
         class Settings:


### PR DESCRIPTION
I've discovered a bug where using `@cbs.envbool(key='FOO')` fails to parse the value of the environment variable, instead always returning the string value passed into the environment.  As strings of any length are truthy, this has gone unnoticed for some time.

The initial commit in this pull request adds a test showing the bug.

Credit to @mylsb for noticing `settings.DEBUG` on a production server wasn't `False`.