### PR TITLE
Travis CI runs tests via tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   - DJANGO="django1.9"
 
 install:
-  - pip install tox --use-mirrors
+  - pip install tox
 
 script:
   - tox -e ${DJANGO}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,27 @@
 sudo: false
+
+os:
+  - linux
+  - osx
+
 language: python
+
 python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
   - "pypy"
   - "pypy3"
+
 env:
-  - DJANGO="Django<1.8"
-  - DJANGO="Django<1.9"
+  - DJANGO="django1.6"
+  - DJANGO="django1.7"
+  - DJANGO="django1.8"
+  - DJANGO="django1.9"
 
 install:
-  - pip install $DJANGO --use-mirrors
+  - pip install tox --use-mirrors
 
 script:
-  - python -m unittest discover
+  - tox -e ${DJANGO}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 sudo: false
 
-os:
-  - linux
-  - osx
-
 language: python
 
 python:

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ usedevelop=False
 
 # all roads lead to `python setup.py test`
 commands=
+  {envpython} -c 'from __future__ import print_function;import platform;print(" ".join([platform.platform(), platform.python_implementation(), platform.python_version()]))'
   coverage run --append --source=cbs setup.py test
 
 # coverage + django factor based (conditional) dependencies


### PR DESCRIPTION
This PR brings all testing together to use the following dependency chain:
`Travis CI` → `tox` → `python setup.py test` → (unittests)

It'd be nice if Travis CI had some documented way of automatically figuring out the build matrix by analysing `tox.ini`.  I looked but couldn't find any docs that suggest it is possible.