### PR TITLE
Add trove classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,14 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Framework :: Django',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7'
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'Intended Audience :: Developers',
     ],
     install_requires=[


### PR DESCRIPTION
[caniusepython3](https://github.com/brettcannon/caniusepython3) says django-classy-settings isn't python3-ready.
Adding the trove "Programming Language" classifiers should stop it complaining.