### PR TITLE
Fix brainfarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ In your `settings.py`
 
     ...
     # For env settings with a DJANGO_ prefix
-    denv = env(prefix='DJANGO_')
+    denv = env['DJANGO_']
 
     class Settings(BaseSettings):
 
-        DEBUG = denv.bool(True)  # Controlled by DJANGO_DEBUG
+        DEBUG = denv.bool(True)  # Controlled by DJANGO_DEBUG env var
 
         DEFAULT_DATABASE = denv.dburl('sqlite://db.sqlite')
 
@@ -37,7 +37,7 @@ In your `settings.py`
         def STATIC_ROOT(self):
             raise ValueError("Must set STATIC_ROOT!")
 
-    __getattr__ = BaseSettings.use()
+    __getattr__, __dir__ = BaseSettings.use()
 
 
 Switch between ``Settings`` and ``ProdSettings`` using the ``DJANGO_MODE`` env var:

--- a/cbs/__init__.py
+++ b/cbs/__init__.py
@@ -151,7 +151,8 @@ class BaseSettings:
         ``getattr__factory`` on it.
 
         :param str env: Envirionment variable to get settings mode name from.
-        :return: functions suitable for module-level ``__getattr__`` and ``__dir__``
+        :return: functions suitable for module-level ``__getattr__`` and
+            ``__dir__``
         """
         base = os.environ.get(env, "")
         name = f"{base.title()}Settings"
@@ -189,7 +190,6 @@ class BaseSettings:
         """
         from inspect import getmodule
 
-        self = cls()
         pkg = getmodule(cls)
 
         keys = [x for x in vars(pkg).keys() if x.isupper()] + [

--- a/cbs/__init__.py
+++ b/cbs/__init__.py
@@ -19,6 +19,7 @@ class env:
     :param func cast: Function to cast ``str`` values.
 
     """
+    PREFIX = ""
 
     def __new__(cls, *args, **kwargs):
         """
@@ -32,7 +33,7 @@ class env:
     def __init__(self, getter, key=None, cast=None, prefix=None):
         self.cast = cast
 
-        self.prefix = prefix or ""
+        self.prefix = prefix or self.PREFIX
 
         self.key = key
 
@@ -62,13 +63,20 @@ class env:
             if self.getter is None:
                 value = self.default
             else:
-                value = self.getter(obj)
+                try:
+                    value = self.getter(obj)
+                except Exception as e:
+                    raise e from None
 
         if self.cast and isinstance(value, str):
             value = self.cast(value)
 
         obj.__dict__[self.key] = value
         return value
+
+    def __class_getitem__(cls, key):
+        """Helper to allow creating env sub-classes with PREFIX pre-set."""
+        return type(f'{cls.__name__}__{key}', (cls,), {'PREFIX': key})
 
     @classmethod
     def bool(cls, *args, **kwargs):
@@ -142,11 +150,17 @@ class BaseSettings:
         ``getattr__factory`` on it.
 
         :param str env: Envirionment variable to get settings mode name from.
-        :return: function suitable for module-level ``__getattr__``
+        :return: functions suitable for module-level ``__getattr__`` and ``__dir__``
         """
         base = os.environ.get(env, "")
         name = f"{base.title()}Settings"
-        return cls.__children[name].getattr_factory()
+
+        Settings = cls.__children[name]
+
+        return (
+            Settings.getattr_factory(),
+            Settings.dir_factory(),
+        )
 
     @classmethod
     def getattr_factory(cls):
@@ -165,3 +179,25 @@ class BaseSettings:
             return val
 
         return __getattr__
+
+    @classmethod
+    def dir_factory(cls):
+        """Returns a function to be used as __dir__ in a module.
+
+        :return: function suitable for module-level ``__dir__``
+        """
+        from inspect import getmodule
+
+        self = cls()
+        pkg = getmodule(cls)
+
+        keys = [
+            x for x in vars(pkg).keys() if x.isupper()
+        ] + [
+            x for x in dir(cls) if x.isupper()
+        ]
+
+        def __dir__(keys=keys):
+            return keys
+
+        return __dir__

--- a/cbs/__init__.py
+++ b/cbs/__init__.py
@@ -19,6 +19,7 @@ class env:
     :param func cast: Function to cast ``str`` values.
 
     """
+
     PREFIX = ""
 
     def __new__(cls, *args, **kwargs):
@@ -76,7 +77,7 @@ class env:
 
     def __class_getitem__(cls, key):
         """Helper to allow creating env sub-classes with PREFIX pre-set."""
-        return type(f'{cls.__name__}__{key}', (cls,), {'PREFIX': key})
+        return type(f"{cls.__name__}__{key}", (cls,), {"PREFIX": key})
 
     @classmethod
     def bool(cls, *args, **kwargs):
@@ -191,9 +192,7 @@ class BaseSettings:
         self = cls()
         pkg = getmodule(cls)
 
-        keys = [
-            x for x in vars(pkg).keys() if x.isupper()
-        ] + [
+        keys = [x for x in vars(pkg).keys() if x.isupper()] + [
             x for x in dir(cls) if x.isupper()
         ]
 

--- a/cbs/cast.py
+++ b/cbs/cast.py
@@ -7,8 +7,8 @@ def as_bool(value: str) -> bool:
 
     :param str value: Value to cast.
         Value will be stripped and ``.lower()``.
-        Values in ``("y", "yes", "on", "t", "true", "1")`` will be treated as True
-        Values in ``("n", "no", "off", "f", "false", "0")`` will be treated as False
+        True values: ``("y", "yes", "on", "t", "true", "1")``
+        False values: ``("n", "no", "off", "f", "false", "0")``
         All other values raise a ``ValueError``
     """
     if isinstance(value, bool):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -187,7 +187,7 @@ might use `django-classy-settings`:
 
     # The `use` method will find the right sub-class of ``BaseSettings`` to use
     # Based on the value of the `DJANGO_MODE` env var.
-    __getattr__ = Settings.use()
+    __getattr__, __dir__ = Settings.use()
 
 
 Now when you start Django, it will use all of your global settings, and any
@@ -220,7 +220,7 @@ The simplest use case is with an immediate value:
 
         FOO = env('default')
 
-    __getattr__ = BaseSettings.use()
+    __getattr__, __dir__ = BaseSettings.use()
 
 
 In this case, if the `FOO` environment variable is set, then ``settings.FOO``
@@ -309,11 +309,11 @@ with `DJANGO_`
 .. code-block:: python
 
     # Common prefix for REDIS related settings
-    denv = env(prefix='DJANGO_')
+    denv = env['DJANGO_']
 
     class Settings(BaseSettings):
 
-        DEBUG = denv(True)
+        DEBUG = denv(True)  # Will look for DJANGO_DEBUG in env
 
 
 Now setting ``DJANGO_DEBUG=f`` will disable debug mode.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ coverage = {extras = ["toml"], version = "^6.4.4"}
 flake8 = "^5.0.4"
 isort = "^5.10.1"
 Sphinx = "^4"
+black = "^22.8.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -2,7 +2,8 @@
 
 from cbs import BaseSettings, env
 
-GLOBAL = 'global'
+GLOBAL = "global"
+
 
 class Settings(BaseSettings):
     DEBUG = True

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -33,4 +33,4 @@ class ProdSettings(Settings):
         return True
 
 
-__getattr__ = BaseSettings.use()
+__getattr__, __dir__ = BaseSettings.use()

--- a/tests/test_cast.py
+++ b/tests/test_cast.py
@@ -11,9 +11,11 @@ class UtilsEnv(unittest.TestCase):
             self.assertTrue(as_bool(value))
         for value in no:
             self.assertFalse(as_bool(value))
-        self.assertRaisesRegex(
-            ValueError, "Unrecognised value for bool: 'blub blah'", as_bool, "blub blah"
-        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "Unrecognised value for bool: 'blub blah'",
+        ):
+            as_bool("blub blah")
 
     def test_as_list(self):
         values = (

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+
+from django.conf import Settings
+
+class DjangoTestCase(TestCase):
+
+    def test_settings(self):
+
+        with self.assertRaises(ValueError):
+            settings = Settings('tests.settings')
+

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -7,4 +7,4 @@ class DjangoTestCase(TestCase):
     def test_settings(self):
 
         with self.assertRaises(ValueError):
-            settings = Settings("tests.settings")
+            Settings("tests.settings")

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -2,10 +2,9 @@ from unittest import TestCase
 
 from django.conf import Settings
 
-class DjangoTestCase(TestCase):
 
+class DjangoTestCase(TestCase):
     def test_settings(self):
 
         with self.assertRaises(ValueError):
-            settings = Settings('tests.settings')
-
+            settings = Settings("tests.settings")

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,7 +1,6 @@
 import os
 import unittest
 
-import cbs
 from cbs import env
 
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -14,17 +14,16 @@ class EnvTestCase(unittest.TestCase):
 
 
 class TestPartial(EnvTestCase):
-
     def test_prefix(self):
 
-        denv = env['DJANGO_']
+        denv = env["DJANGO_"]
 
         class Settings:
-            SETTING = denv('value')
+            SETTING = denv("value")
             BOOL = denv.bool(True)
 
-        os.environ['DJANGO_SETTING'] = 'override'
-        self.assertEqual(Settings().SETTING, 'override')
+        os.environ["DJANGO_SETTING"] = "override"
+        self.assertEqual(Settings().SETTING, "override")
 
 
 class TestImmediate(EnvTestCase):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -13,6 +13,20 @@ class EnvTestCase(unittest.TestCase):
         os.environ.clear()
 
 
+class TestPartial(EnvTestCase):
+
+    def test_prefix(self):
+
+        denv = env['DJANGO_']
+
+        class Settings:
+            SETTING = denv('value')
+            BOOL = denv.bool(True)
+
+        os.environ['DJANGO_SETTING'] = 'override'
+        self.assertEqual(Settings().SETTING, 'override')
+
+
 class TestImmediate(EnvTestCase):
     def test_default(self):
         class Settings:

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -6,7 +6,8 @@ from cbs.urls import parse_dburl
 class TestUrlParse(TestCase):
     def test_simple(self):
         result = parse_dburl(
-            "postgres://user:password@hostname:1234/dbname?conn_max_age=15&local_option=test"
+            "postgres://user:password@hostname:1234/dbname"
+            "?conn_max_age=15&local_option=test"
         )
 
         self.assertEqual(
@@ -29,5 +30,9 @@ class TestUrlParse(TestCase):
         result = parse_dburl("sqlite:///db.sqlite")
 
         self.assertEqual(
-            result, {"ENGINE": "django.db.backends.sqlite3", "NAME": "db.sqlite"}
+            result,
+            {
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": "db.sqlite",
+            },
         )

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -12,7 +12,7 @@ class TestSettingsUse(unittest.TestCase):
     def test_use(self):
         importlib.reload(settings)
 
-        self.assertEqual(settings.GLOBAL, 'global')
+        self.assertEqual(settings.GLOBAL, "global")
 
         self.assertTrue(settings.DEBUG)
         self.assertEqual(settings.STR_ENV, "default")


### PR DESCRIPTION
After first attempts to use, discovered some critical flaws:

1. Django `Settings` uses `dir()`, so we must implement `__dir__` also, or it won't find our settings.
2. The pre-set prefix pattern didn't allow access to the classmethod shortcuts (e.g. env.bool) because it returned a `partial`.


(1) is fixed and now requires using:
```
__getattr__, __dir__ = BaseSettings.use()
```

(2) is fixed by switching the approach, using `env[prefix]` to create a new sub-class with the specified prefix.
