### PR TITLE
Housekeeping

### DIFF
--- a/cbs/env.py
+++ b/cbs/env.py
@@ -45,6 +45,10 @@ class env:
             return partial(cls, **kwargs)
         return object.__new__(cls)
 
+    def __class_getitem__(cls, key):
+        """Helper to allow creating env sub-classes with PREFIX pre-set."""
+        return type(f"{cls.__name__}__{key}", (cls,), {"PREFIX": key})
+
     def __init__(self, getter, key=None, cast=None, prefix=None):
         self.cast = cast
 
@@ -91,10 +95,6 @@ class env:
 
     def __call__(self):
         return self.__get__(self)
-
-    def __class_getitem__(cls, key):
-        """Helper to allow creating env sub-classes with PREFIX pre-set."""
-        return type(f"{cls.__name__}__{key}", (cls,), {"PREFIX": key})
 
     @classmethod
     def bool(cls, *args, **kwargs):

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -48,3 +48,9 @@ class TestSettingsUse(unittest.TestCase):
         self.assertEqual(settings.STR_ENV, "override")
         self.assertFalse(settings.BOOL_ENV)
         self.assertEqual(settings.METHOD, "False")
+
+    def test_use_unknown(self):
+        os.environ["DJANGO_MODE"] = "mystery"
+
+        with self.assertRaises(ValueError, msg="Could not find Settings class for mode 'mystery' (Known: Settings, ProdSettings, GlobalSettings)"):
+            importlib.reload(settings)


### PR DESCRIPTION
Ensure settings class is only instantiated once per use() call
Break up `use` into smaller parts
Raise more useful error if settings class for mode does not exist
