### PR TITLE
add support for .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # Vim
 .*.swp
+
+# pycharm
+.idea/

--- a/cbs/env.py
+++ b/cbs/env.py
@@ -18,7 +18,6 @@ __all__ = ['env']
 # + DB Config: db-url
 # - Cache Config: db-url
 
-
 class env:
     """property to make environment variable based settings simpler.
 
@@ -31,6 +30,9 @@ class env:
     :param func cast: Function to cast ``str`` values.
 
     """
+
+    class Required:
+        pass
 
     PREFIX = ""
 
@@ -54,7 +56,7 @@ class env:
         self.key = key
         self.prefix = prefix or self.PREFIX
 
-        if callable(getter):
+        if getter is not self.Required and callable(getter):
             self.getter = getter
         else:
             self.getter = None
@@ -76,6 +78,8 @@ class env:
             value = os.environ[self.env_name]
         except KeyError:
             if self.getter is None:
+                if self.default is self.Required:
+                    raise ValueError(f"Environment varariable {self.env_name} is required but not set.")
                 value = self.default
             else:
                 try:

--- a/cbs/settings.py
+++ b/cbs/settings.py
@@ -58,6 +58,9 @@ class BaseSettings:
                     "try `pip install django-classy-settings[environ]`"
                 )
 
+            if not os.path.exists(env_path):
+                raise ValueError(f"'{env_path}' does not exist")
+
             env = environ.Env()
             env.read_env(env_path)
             base = env.str(env)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ isort = "^5.10.1"
 Sphinx = "^4"
 black = "^22.8.0"
 
+[tool.poetry.extras]
+environ = ["django-environ"]
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -39,6 +39,15 @@ class TestPartial(EnvTestCase):
         self.assertEqual(Settings().SETTING, "override")
 
 
+class TestRequired(EnvTestCase):
+    def test_required(self):
+        TEST = env(env.Required)
+        TEST.key = 'TEST'   # This is normally set via __set_name__
+
+        with self.assertRaises(ValueError, msg="Env var TEST is required but not set"):
+            TEST()
+
+
 class TestCallable(EnvTestCase):
     def test_default(self):
         TEST = env("default", key="TEST")


### PR DESCRIPTION
closes#47
i have made these changes:

1- added django-environ as an optional dependency
you could either make it a required dependency
or make the methods more abstract so users can use whatever parsing tool they want.

2- add one optional parameter to `use()` and `get_settings_instance()` methods
if the user provides a path, it will be used
othersie it defaluts to None and methods go as they did before
also some safty check just in case, and some docstrings

3- added .idea to .gitignore for pycharm

let me know if you have any thoughts on this