### PR TITLE
add support for .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # Vim
 .*.swp
+
+# pycharm
+.idea/

--- a/cbs/settings.py
+++ b/cbs/settings.py
@@ -19,17 +19,18 @@ class BaseSettings:
         return val
 
     @classmethod
-    def use(cls, env="DJANGO_MODE"):
+    def use(cls, env="DJANGO_MODE", env_path=None):
         """Helper for accessing sub-classes via env var name.
 
         Gets a sub-class instance using ``get_settings_instance``, and returns
         the results of calling ``getattr__factory`` and ``dir_factory`` on it.
 
-        :param str env: Envirionment variable to get settings mode name from.
+        :param str env: Environment variable to get settings mode name from.
+        :param str env_path: the path to the file containing the environment variable, if left empty, os.environ will be used instead.
         :return: functions suitable for module-level ``__getattr__`` and
             ``__dir__``
         """
-        settings = cls.get_settings_instance(env)
+        settings = cls.get_settings_instance(env, env_path)
 
         return (
             settings.getattr_factory(),
@@ -37,7 +38,7 @@ class BaseSettings:
         )
 
     @classmethod
-    def get_settings_instance(cls, env="DJANGO_MODE"):
+    def get_settings_instance(cls, env="DJANGO_MODE", env_path=None):
         """Create an instance of the appropriate Settings sub-class.
 
         Takes the value of ``os.environ[env]``, calls ``.title()`` on it, then
@@ -48,6 +49,22 @@ class BaseSettings:
 
         """
         base = os.environ.get(env, "")
+
+        if env_path:
+            try:
+                import eniron
+            except ImportError:
+                raise ImportError(
+                    "if you want to read your environment variables from a file, "
+                    "you need to install the optional `django-environ` package"
+                    "try `pip install django-classy-settings[environ]`"
+                )
+
+            if os.path.exists(env_path):
+                env = environ.Env()
+                env.read_env(env_path)
+                base = env.str(env)
+
         name = f"{base.title()}Settings"
 
         try:

--- a/cbs/settings.py
+++ b/cbs/settings.py
@@ -41,8 +41,9 @@ class BaseSettings:
     def get_settings_instance(cls, env="DJANGO_MODE", env_path=None):
         """Create an instance of the appropriate Settings sub-class.
 
-        Takes the value of ``os.environ[env]``, calls ``.title()`` on it, then
-        appends `"Settings"`.
+        Takes the value of ``os.environ[env]``, calls ``.title()`` on it,
+        or reads the value from the specified file in ``env_path``,
+        then appends `"Settings"`.
 
         It will then find a sub-class of that name, and return an instance of
         it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ isort = "^5.10.1"
 Sphinx = "^4"
 black = "^22.8.0"
 
+[tool.poetry.extras]
+environ = ["django-environ"]
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
closes#47

i have made these changes:

1- added django-environ as an optional dependency
you could either make it a required dependency
or make the methods more abstract so users can use whatever parsing tool they want.

2- add one optional parameter to use() and get_settings_instance() methods
if the user provides a path, it will be used
othersie it defaluts to None and methods go as they did before
if a file path is given but the file doesn't exist, fallback to os.environ. (useful for ci/cd when .env file isn't available)
also some safty check just in case, and some docstrings

3- added .idea to .gitignore for pycharm

let me know if you have any thoughts on this