### PR TITLE
Evaluate module level dir every call to __dir__

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,9 @@ Features Added:
 
 - A default for `DJANGO_MODE` can now be specified when calling `Settings.use()`
 
+- `__dir__` now re-inspects the module every time it's invoked for global properties.
+  This avoids hiding any values defined after `.use()` is called.
+
 3.0.6 (2024-09-18)
 ------------------
 

--- a/src/cbs/settings.py
+++ b/src/cbs/settings.py
@@ -92,12 +92,6 @@ class BaseSettings:
 
         pkg = getmodule(self.__class__)
 
-        package_settings = [
-            name
-            for name in vars(pkg).keys()
-            if name.isupper()
-        ]  # fmt: skip
-
         class_settings = [
             name
             for name, value in getmembers(self)
@@ -105,12 +99,18 @@ class BaseSettings:
             and value is not Unset
         ]  # fmt: skip
 
-        overlap = set(package_settings).intersection(class_settings)
-
-        if overlap:
-            warn(f"Masked settings in {self.__class__.__name__}: {overlap}")
-
         def __dir__():  # noqa: N807
+            package_settings = [
+                name
+                for name in vars(pkg).keys()
+                if name.isupper()
+            ]  # fmt: skip
+
+            overlap = set(package_settings).intersection(class_settings)
+
+            if overlap:
+                warn(f"Masked settings in {self.__class__.__name__}: {overlap}")
+
             return package_settings + class_settings
 
         return __dir__

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -54,3 +54,6 @@ class GlobalSettings(Settings):
 
 
 __getattr__, __dir__ = BaseSettings.use(default=os.environ.get("mode", ""))
+
+
+LATE_SETTING = True

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,3 +24,10 @@ class TestPython(unittest.TestCase):
         Ensure when we access nested SHOUTY_SNAKE_CASE we still treat methods as properties.
         '''
         self.assertEqual(settings.METHOD, settings.NESTED)
+
+    def test_late(self):
+        '''
+        Don't hide any module level values defined after `BaseSettings.use()` is called.
+        '''
+        self.assertTrue(hasattr(settings, "LATE_SETTING"))
+        self.assertTrue(settings.LATE_SETTING)

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -82,7 +82,7 @@ class TestSettingsUse(unittest.TestCase):
 
         with self.assertWarns(UserWarning):
             importlib.reload(settings)
-
+            dir(settings)
 
     def test_incomplete(self):
         os.environ["DJANGO_MODE"] = "incomplete"


### PR DESCRIPTION
Previously the list of available properties was evaluated when `BaseSettings.use()` was invoked.

This had the unintended side-effect of hiding any settings outside of classes defined after it's called.

This PR moves this to inside the generated `__dir__` function, along with the masking check.