### PR TITLE
Don't cache properties on lookup; it can cause some odd behaviors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Django Classy Settings documentation build configuration file, created by
 # sphinx-quickstart on Thu Jul 24 13:53:10 2014.
@@ -12,8 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/src/cbs/env.py
+++ b/src/cbs/env.py
@@ -91,7 +91,6 @@ class env:  # noqa: N801
         if self.cast and isinstance(value, str):
             value = self.cast(value)
 
-        obj.__dict__[self.key] = value
         return value
 
     def __call__(self):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -37,12 +37,10 @@ class ProdSettings(Settings):
 
 
 class RequiredSettings(BaseSettings):
-
     STR_REQUIRED = env(env.Required)
 
 
 class IncompleteSettings(BaseSettings):
-
     # Must have a default, or a getter (e.g. used as decorator)
     INCOMPLETE = env(key="FOO")
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,7 +6,6 @@ from . import settings  # So reload works first time
 
 
 class TestPython(unittest.TestCase):
-
     def test_precedence(self):
         os.environ["DJANGO_MODE"] = "global"
 
@@ -15,19 +14,20 @@ class TestPython(unittest.TestCase):
         self.assertEqual(settings.GLOBAL, "global")
 
     def test_non_upper(self):
-        '''We only allow access to SHOUTY_SNAKE_CASE names.'''
+        """We only allow access to SHOUTY_SNAKE_CASE names."""
         with self.assertRaises(AttributeError):
             settings.private
 
     def test_nested(self):
-        '''
+        """
         Ensure when we access nested SHOUTY_SNAKE_CASE we still treat methods as properties.
-        '''
+        """
         self.assertEqual(settings.METHOD, settings.NESTED)
+        self.assertEqual(settings.NESTED, str(settings.DEBUG))
 
     def test_late(self):
-        '''
+        """
         Don't hide any module level values defined after `BaseSettings.use()` is called.
-        '''
+        """
         self.assertTrue(hasattr(settings, "LATE_SETTING"))
         self.assertTrue(settings.LATE_SETTING)

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -5,5 +5,4 @@ from django.conf import Settings
 
 class DjangoTestCase(TestCase):
     def test_settings(self):
-
         Settings("tests.settings")

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -28,7 +28,6 @@ class TestProperty(EnvTestCase):
 
 class TestPartial(EnvTestCase):
     def test_prefix(self):
-
         denv = env["DJANGO_"]
 
         class Settings:
@@ -42,7 +41,7 @@ class TestPartial(EnvTestCase):
 class TestRequired(EnvTestCase):
     def test_required(self):
         TEST = env(env.Required)
-        TEST.key = 'TEST'   # This is normally set via __set_name__
+        TEST.key = "TEST"  # This is normally set via __set_name__
 
         with self.assertRaises(ValueError, msg="Env var TEST is required but not set"):
             TEST()
@@ -57,7 +56,7 @@ class TestCallable(EnvTestCase):
         self.assertEqual(TEST(), "test")
 
     def test_no_arguments(self):
-        '''
+        """
         env() can't sensibly be called without _any_ arguments.
 
         Proper usage is one of:
@@ -71,7 +70,7 @@ class TestCallable(EnvTestCase):
 
             @env(key=value, ...)
             def foo(...):
-        '''
+        """
         with self.assertRaises(TypeError):
             env()
 
@@ -171,7 +170,6 @@ class TestMethod(EnvTestCase):
 class EnvBoolTest(EnvTestCase):
     def test_immediate(self):
         class Settings:
-
             DEBUG = env.bool(False)
 
         os.environ["DEBUG"] = "y"
@@ -199,28 +197,22 @@ class EnvBoolTest(EnvTestCase):
         # True values
         for tval in ("y", "yes", "on", "t", "true", "1"):
             os.environ["SETTING"] = tval
-            del s.SETTING
             self.assertTrue(s.SETTING)
 
             os.environ["SETTING"] = tval.title()
-            del s.SETTING
             self.assertTrue(s.SETTING)
 
             os.environ["SETTING"] = tval.upper()
-            del s.SETTING
             self.assertTrue(s.SETTING)
 
         for fval in ("n", "no", "off", "f", "false", "0"):
             os.environ["SETTING"] = fval
-            del s.SETTING
             self.assertFalse(s.SETTING)
 
             os.environ["SETTING"] = fval.title()
-            del s.SETTING
             self.assertFalse(s.SETTING)
 
             os.environ["SETTING"] = fval.upper()
-            del s.SETTING
             self.assertFalse(s.SETTING)
 
     def test_env_bool_set_invalid(self):

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -5,10 +5,7 @@ from cbs.urls import parse_dburl
 
 class TestUrlParse(TestCase):
     def test_simple(self):
-        result = parse_dburl(
-            "postgres://user:password@hostname:1234/dbname"
-            "?conn_max_age=15&local_option=test"
-        )
+        result = parse_dburl("postgres://user:password@hostname:1234/dbname?conn_max_age=15&local_option=test")
 
         self.assertEqual(
             result,

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -64,8 +64,7 @@ class TestSettingsUse(unittest.TestCase):
 
         with self.assertRaises(
             ValueError,
-            msg="Could not find Settings class for mode 'mystery' "
-                "(Known: Settings, ProdSettings, GlobalSettings)",
+            msg="Could not find Settings class for mode 'mystery' (Known: Settings, ProdSettings, GlobalSettings)",
         ):
             importlib.reload(settings)
 
@@ -89,4 +88,3 @@ class TestSettingsUse(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             importlib.reload(settings)
-


### PR DESCRIPTION
Also run `ruff check --fix` and `ruff format` over the code.